### PR TITLE
Move to using ruby/setup-ruby to restore CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Linux dependencies
       run: sudo apt-get update -qq && sudo apt-get install -y libsqlite3-dev
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1.1.1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6.6
     - name: Cache gems


### PR DESCRIPTION
This PR moves away from the deprecated `actions/setup-ruby` to `ruby/setup-ruby` within the projects GitHub actions CI config.