### PR TITLE
Fix CI + Fix bundled type annotations not working under recent Sorbet versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Linux dependencies
       run: sudo apt-get update -qq && sudo apt-get install -y libsqlite3-dev
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1.1.1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6.6
     - name: Cache gems

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+UNRELEASED
+
+* Fix bundled RBI being incompatible with recent Sorbet releases due to `params()` and invalid use of `sealed!`.
+
 1.1.5
 
 * Fix inaccurate type annotations for `Dry::Monads::Maybe#fmap` and `Dry::Monads::Result#fmap`.

--- a/dry-monads-sorbet.gemspec
+++ b/dry-monads-sorbet.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
     dry-monads-sorbet has been installed/updated.
 
     This gem ships with a bundled rbi file that must be copied into your project.
-    You can use the included "dry_monads_sorbet:update_rbi" to do this.
+    You can use the included "dry_monads_sorbet:update_rbi" Rake task to do this.
   TEXT
 
   spec.add_dependency 'sorbet'

--- a/lib/bundled_rbi/dry-monads.rbi
+++ b/lib/bundled_rbi/dry-monads.rbi
@@ -45,8 +45,9 @@ class Dry::Monads::Maybe
   extend T::Generic
   extend T::Helpers
 
+  Elem = type_member
+
   abstract!
-  sealed!
 
   sig do
     type_parameters(:New)
@@ -131,7 +132,7 @@ class Dry::Monads::Maybe::None < Dry::Monads::Maybe
   def deconstruct; end
   def eql?(other); end
   def hash; end
-  sig {params().void}
+  sig {void}
   def initialize(); end
   def inspect; end
   def maybe(*arg0); end
@@ -149,7 +150,7 @@ end
 module Dry::Monads::Maybe::Mixin::Constructors
   sig {type_parameters(:T).params(value: T.nilable(T.type_parameter(:T))).returns(Dry::Monads::Maybe[T.type_parameter(:T)])}
   def Maybe(value); end
-  sig {type_parameters(:T).params().returns(Dry::Monads::Maybe[T.type_parameter(:out, :T)])}
+  sig {type_parameters(:T).returns(Dry::Monads::Maybe[T.type_parameter(:out, :T)])}
   def None; end
   sig {type_parameters(:T).params(value: T.type_parameter(:T)).returns(Dry::Monads::Maybe[T.type_parameter(:T)])}
   def Some(value = nil); end
@@ -164,7 +165,6 @@ class Dry::Monads::Result
   extend T::Helpers
 
   abstract!
-  sealed!
 
   sig do
     type_parameters(:NewSuccessType)

--- a/lib/bundled_rbi/dry-monads.rbi
+++ b/lib/bundled_rbi/dry-monads.rbi
@@ -164,6 +164,9 @@ class Dry::Monads::Result
   extend T::Generic
   extend T::Helpers
 
+  FailureType = type_member
+  SuccessType = type_member
+
   abstract!
 
   sig do

--- a/sorbet/config
+++ b/sorbet/config
@@ -1,2 +1,4 @@
 --dir
 .
+--ignore
+/lib/dry/monads/sorbet.rb


### PR DESCRIPTION
This PR gets the GitHub Actions CI working again and fixes an issue with the bundler RBI file not working correctly under recent Sorbet releases due to use of `params()` and some invalid use of `sealed!`.

We had made this changes internally on some @tricycle projects but hadn't yet extracted them to the gem.